### PR TITLE
Fixes the ecrecover precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libgoldilocks"
+version = "0.1.0"
+source = "git+https://github.com/core-coin/ed448-rs?branch=david/add_try_from_for_signature#d27fde3a32814f43f58f7e2202173dec90784e6c"
+dependencies = [
+ "hex",
+ "rand",
+ "sha3",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1191,7 @@ version = "2.0.0"
 dependencies = [
  "hex",
  "k256",
+ "libgoldilocks",
  "num",
  "once_cell",
  "revm-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 [[package]]
 name = "libgoldilocks"
 version = "0.1.0"
-source = "git+https://github.com/core-coin/ed448-rs?branch=david/add_try_from_for_signature#d27fde3a32814f43f58f7e2202173dec90784e6c"
+source = "git+https://github.com/core-coin/ed448-rs#1e7c8738732a104c63480880b597fd850b2fafa4"
 dependencies = [
  "hex",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -16,13 +16,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0fac0fc16baf1f63f78b47c3d24718f3619b0714076f6a02957d808d52cbef"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
  "arrayvec",
  "bytes",
- "smol_str",
 ]
 
 [[package]]
@@ -36,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -87,7 +86,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -97,7 +96,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -109,7 +108,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
  "num-traits",
- "quote 1.0.33",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -121,8 +120,8 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -191,8 +190,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -323,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -335,9 +334,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -385,20 +384,20 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]
 
 [[package]]
@@ -408,8 +407,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -483,9 +482,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]
 
 [[package]]
@@ -496,12 +495,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -546,7 +545,7 @@ dependencies = [
 [[package]]
 name = "fixed-hash"
 version = "0.8.0"
-source = "git+https://github.com/core-coin/core-common.git#42b827b843fecd2c0dda6468a70bf5f84d4d3399"
+source = "git+https://github.com/core-coin/core-common.git#6887ba42dc17baaa96bd75b1e88d9c6db0789abe"
 dependencies = [
  "rand",
  "rustc-hex",
@@ -577,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -615,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -694,19 +693,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -742,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "k256"
@@ -779,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libgoldilocks"
@@ -801,15 +800,15 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "microbench"
@@ -902,15 +901,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.5"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
+checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -922,13 +921,13 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.5"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
+checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -960,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b559898e0b4931ed2d3b959ab0c2da4d99cc644c4b0b1a35b4d344027f474023"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"
@@ -973,7 +972,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primitive-types"
 version = "0.12.1"
-source = "git+https://github.com/core-coin/core-common.git#42b827b843fecd2c0dda6468a70bf5f84d4d3399"
+source = "git+https://github.com/core-coin/core-common.git#6887ba42dc17baaa96bd75b1e88d9c6db0789abe"
 dependencies = [
  "fixed-hash 0.8.0 (git+https://github.com/core-coin/core-common.git)",
  "uint 0.9.5 (git+https://github.com/core-coin/core-common.git)",
@@ -994,11 +993,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
- "once_cell",
+ "toml_datetime",
  "toml_edit",
 ]
 
@@ -1009,8 +1008,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1021,8 +1020,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "version_check",
 ]
 
@@ -1037,18 +1036,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "2dd5e8a1f1029c43224ad5898e50140c2aebb1705f19e67c918ebf5b9e797fe1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1092,11 +1091,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "22a37c9326af5ed140c86a46655b5278de879853be5573c01df185b6f49a580a"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.73",
 ]
 
 [[package]]
@@ -1146,18 +1145,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "revm"
@@ -1292,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.5.2"
-source = "git+https://github.com/core-coin/core-common.git#42b827b843fecd2c0dda6468a70bf5f84d4d3399"
+source = "git+https://github.com/core-coin/core-common.git#6887ba42dc17baaa96bd75b1e88d9c6db0789abe"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -1300,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -1311,6 +1310,7 @@ dependencies = [
  "bytes",
  "fastrlp",
  "num-bigint",
+ "num-traits",
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
@@ -1354,15 +1354,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -1449,29 +1449,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1511,15 +1511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smol_str"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,8 +1547,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "syn 1.0.109",
 ]
 
@@ -1597,19 +1588,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0eae3c679c56dc214320b67a1bc04ef3dfbd6411f6443974b5e4893231298e66"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
  "unicode-ident",
 ]
 
@@ -1621,15 +1612,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1643,35 +1634,35 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "b2cd5904763bad08ad5513ddbb12cf2ae273ca53fa9f68e843e236ec6dfccc09"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "3dcf4a824cce0aeacd6f38ae6f24234c8e80d68632338ebaa1443b5df9e29e19"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1715,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "uint"
 version = "0.9.5"
-source = "git+https://github.com/core-coin/core-common.git#42b827b843fecd2c0dda6468a70bf5f84d4d3399"
+source = "git+https://github.com/core-coin/core-common.git#6887ba42dc17baaa96bd75b1e88d9c6db0789abe"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1838,11 +1829,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1862,17 +1853,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1883,9 +1874,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1895,9 +1886,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1907,9 +1898,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1919,9 +1910,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1931,9 +1922,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1943,9 +1934,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1955,15 +1946,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "97a4882e6b134d6c28953a387571f1acdd3496830d5e36c5e3a1075580ea641c"
 dependencies = [
  "memchr",
 ]
@@ -1979,29 +1970,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -2012,7 +2003,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.73",
+ "quote 1.0.34",
+ "syn 2.0.45",
 ]

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -2,14 +2,14 @@
 authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
 description = "REVM Precompiles - Ethereum compatible precompiled contracts"
 edition = "2021"
-keywords = ["no_std", "ethereum", "evm", "revm", "precompiles"]
+keywords = ["ethereum", "evm", "revm", "precompiles"]
 license = "MIT"
 name = "revm-precompile"
 repository = "https://github.com/bluealloy/revm"
 version = "2.0.0"
 
 [dependencies]
-revm-primitives = { path = "../primitives", version="1.0.0", default-features = false }
+revm-primitives = { path = "../primitives", version = "1.0.0" }
 bn = { package = "substrate-bn", version = "0.6", default-features = false }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -18,6 +18,8 @@ ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["alloc", "recovery"], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
+libgoldilocks = { git = "https://github.com/core-coin/ed448-rs", branch = "david/add_try_from_for_signature" }
+
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -23,11 +23,3 @@ libgoldilocks = { git = "https://github.com/core-coin/ed448-rs" }
 
 [dev-dependencies]
 hex = "0.4"
-
-[features]
-default = ["secp256k1"]
-# secp256k1 is used as faster alternative to k256 lib. And in most cases should be default.
-# Only problem that it has, it fails to build for wasm target on windows and mac as it is c lib.
-# If you dont require wasm on win/mac, i would recommend its usage.
-secp256k1 = ["dep:secp256k1"]
-

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -18,7 +18,7 @@ ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.27.0", default-features = false, features = ["alloc", "recovery"], optional = true }
 sha2 = { version = "0.10.5", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-libgoldilocks = { git = "https://github.com/core-coin/ed448-rs", branch = "david/add_try_from_for_signature" }
+libgoldilocks = { git = "https://github.com/core-coin/ed448-rs" }
 
 
 [dev-dependencies]

--- a/crates/precompile/src/blake2.rs
+++ b/crates/precompile/src/blake2.rs
@@ -1,3 +1,5 @@
+use revm_primitives::Network;
+
 use crate::{Error, PrecompileAddress, StandardPrecompileFn};
 use crate::{Precompile, PrecompileResult};
 use core::convert::TryInto;
@@ -13,7 +15,7 @@ pub const FUN: PrecompileAddress = PrecompileAddress(
 /// reference: https://eips.ethereum.org/EIPS/eip-152
 /// input format:
 /// [4 bytes for rounds][64 bytes for h][128 bytes for m][8 bytes for t_0][8 bytes for t_1][1 byte for f]
-fn run(input: &[u8], energy_limit: u64) -> PrecompileResult {
+fn run(input: &[u8], energy_limit: u64, _: Network) -> PrecompileResult {
     if input.len() != INPUT_LENGTH {
         return Err(Error::Blake2WrongLength);
     }

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -1,5 +1,4 @@
 use crate::{primitives::U256, Error, Precompile, PrecompileAddress, PrecompileResult, B176};
-use alloc::vec::Vec;
 
 pub mod add {
     use super::*;

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -1,12 +1,14 @@
 use crate::{primitives::U256, Error, Precompile, PrecompileAddress, PrecompileResult, B176};
 
 pub mod add {
+    use revm_primitives::Network;
+
     use super::*;
     const ADDRESS: B176 = crate::u64_to_b176(6);
 
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
             if 150 > target_energy {
                 return Err(Error::OutOfEnergy);
             }
@@ -16,7 +18,7 @@ pub mod add {
 
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
             if 500 > target_energy {
                 return Err(Error::OutOfEnergy);
             }
@@ -26,11 +28,12 @@ pub mod add {
 }
 
 pub mod mul {
+    use revm_primitives::Network;
     use super::*;
     const ADDRESS: B176 = crate::u64_to_b176(7);
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], energy_limit: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
             if 6_000 > energy_limit {
                 return Err(Error::OutOfEnergy);
             }
@@ -40,7 +43,7 @@ pub mod mul {
 
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], energy_limit: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
             if 40_000 > energy_limit {
                 return Err(Error::OutOfEnergy);
             }
@@ -50,6 +53,8 @@ pub mod mul {
 }
 
 pub mod pair {
+    use revm_primitives::Network;
+
     use super::*;
     const ADDRESS: B176 = crate::u64_to_b176(8);
 
@@ -57,7 +62,7 @@ pub mod pair {
     const ISTANBUL_PAIR_BASE: u64 = 45_000;
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
             super::run_pair(
                 input,
                 ISTANBUL_PAIR_PER_POINT,
@@ -71,7 +76,7 @@ pub mod pair {
     const BYZANTIUM_PAIR_BASE: u64 = 100_000;
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64| -> PrecompileResult {
+        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
             super::run_pair(
                 input,
                 BYZANTIUM_PAIR_PER_POINT,

--- a/crates/precompile/src/bn128.rs
+++ b/crates/precompile/src/bn128.rs
@@ -8,47 +8,55 @@ pub mod add {
 
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
-            if 150 > target_energy {
-                return Err(Error::OutOfEnergy);
-            }
-            Ok((150, super::run_add(input)?))
-        }),
+        Precompile::Standard(
+            |input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
+                if 150 > target_energy {
+                    return Err(Error::OutOfEnergy);
+                }
+                Ok((150, super::run_add(input)?))
+            },
+        ),
     );
 
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
-            if 500 > target_energy {
-                return Err(Error::OutOfEnergy);
-            }
-            Ok((500, super::run_add(input)?))
-        }),
+        Precompile::Standard(
+            |input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
+                if 500 > target_energy {
+                    return Err(Error::OutOfEnergy);
+                }
+                Ok((500, super::run_add(input)?))
+            },
+        ),
     );
 }
 
 pub mod mul {
-    use revm_primitives::Network;
     use super::*;
+    use revm_primitives::Network;
     const ADDRESS: B176 = crate::u64_to_b176(7);
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
-            if 6_000 > energy_limit {
-                return Err(Error::OutOfEnergy);
-            }
-            Ok((6_000, super::run_mul(input)?))
-        }),
+        Precompile::Standard(
+            |input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
+                if 6_000 > energy_limit {
+                    return Err(Error::OutOfEnergy);
+                }
+                Ok((6_000, super::run_mul(input)?))
+            },
+        ),
     );
 
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
-            if 40_000 > energy_limit {
-                return Err(Error::OutOfEnergy);
-            }
-            Ok((40_000, super::run_mul(input)?))
-        }),
+        Precompile::Standard(
+            |input: &[u8], energy_limit: u64, _: Network| -> PrecompileResult {
+                if 40_000 > energy_limit {
+                    return Err(Error::OutOfEnergy);
+                }
+                Ok((40_000, super::run_mul(input)?))
+            },
+        ),
     );
 }
 
@@ -62,28 +70,32 @@ pub mod pair {
     const ISTANBUL_PAIR_BASE: u64 = 45_000;
     pub const ISTANBUL: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
-            super::run_pair(
-                input,
-                ISTANBUL_PAIR_PER_POINT,
-                ISTANBUL_PAIR_BASE,
-                target_energy,
-            )
-        }),
+        Precompile::Standard(
+            |input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
+                super::run_pair(
+                    input,
+                    ISTANBUL_PAIR_PER_POINT,
+                    ISTANBUL_PAIR_BASE,
+                    target_energy,
+                )
+            },
+        ),
     );
 
     const BYZANTIUM_PAIR_PER_POINT: u64 = 80_000;
     const BYZANTIUM_PAIR_BASE: u64 = 100_000;
     pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
         ADDRESS,
-        Precompile::Standard(|input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
-            super::run_pair(
-                input,
-                BYZANTIUM_PAIR_PER_POINT,
-                BYZANTIUM_PAIR_BASE,
-                target_energy,
-            )
-        }),
+        Precompile::Standard(
+            |input: &[u8], target_energy: u64, _: Network| -> PrecompileResult {
+                super::run_pair(
+                    input,
+                    BYZANTIUM_PAIR_PER_POINT,
+                    BYZANTIUM_PAIR_BASE,
+                    target_energy,
+                )
+            },
+        ),
     );
 }
 

--- a/crates/precompile/src/hash.rs
+++ b/crates/precompile/src/hash.rs
@@ -1,5 +1,6 @@
 use super::calc_linear_cost_u32;
 use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, StandardPrecompileFn};
+use revm_primitives::Network;
 use sha2::*;
 
 pub const SHA256: PrecompileAddress = PrecompileAddress(
@@ -14,7 +15,7 @@ pub const RIPEMD160: PrecompileAddress = PrecompileAddress(
 /// See: https://ethereum.github.io/yellowpaper/paper.pdf
 /// See: https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions
 /// See: https://etherscan.io/address/0000000000000000000000000000000000000002
-fn sha256_run(input: &[u8], energy_limit: u64) -> PrecompileResult {
+fn sha256_run(input: &[u8], energy_limit: u64, _: Network) -> PrecompileResult {
     let cost = calc_linear_cost_u32(input.len(), 60, 12);
     if cost > energy_limit {
         Err(Error::OutOfEnergy)
@@ -27,7 +28,7 @@ fn sha256_run(input: &[u8], energy_limit: u64) -> PrecompileResult {
 /// See: https://ethereum.github.io/yellowpaper/paper.pdf
 /// See: https://docs.soliditylang.org/en/develop/units-and-global-variables.html#mathematical-and-cryptographic-functions
 /// See: https://etherscan.io/address/0000000000000000000000000000000000000003
-fn ripemd160_run(input: &[u8], energy_limit: u64) -> PrecompileResult {
+fn ripemd160_run(input: &[u8], energy_limit: u64, _: Network) -> PrecompileResult {
     let energy_used = calc_linear_cost_u32(input.len(), 600, 120);
     if energy_used > energy_limit {
         Err(Error::OutOfEnergy)

--- a/crates/precompile/src/identity.rs
+++ b/crates/precompile/src/identity.rs
@@ -1,3 +1,5 @@
+use revm_primitives::Network;
+
 use super::calc_linear_cost_u32;
 use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, StandardPrecompileFn};
 
@@ -15,7 +17,7 @@ const IDENTITY_PER_WORD: u64 = 3;
 ///
 /// See: https://ethereum.github.io/yellowpaper/paper.pdf
 /// See: https://etherscan.io/address/0000000000000000000000000000000000000004
-fn identity_run(input: &[u8], energy_limit: u64) -> PrecompileResult {
+fn identity_run(input: &[u8], energy_limit: u64, _: Network) -> PrecompileResult {
     let energy_used = calc_linear_cost_u32(input.len(), IDENTITY_BASE, IDENTITY_PER_WORD);
     if energy_used > energy_limit {
         return Err(Error::OutOfEnergy);

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -17,7 +17,6 @@ pub type B176 = [u8; 22];
 pub type B160 = [u8; 20];
 pub type B256 = [u8; 32];
 
-
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     (len as u64 + 32 - 1) / 32 * word + base
 }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -1,5 +1,3 @@
-#![no_std]
-
 mod blake2;
 mod bn128;
 mod hash;
@@ -13,16 +11,12 @@ pub use primitives::{
     Bytes, HashMap,
 };
 pub use revm_primitives as primitives;
+pub use std::fmt;
 
 pub type B176 = [u8; 22];
 pub type B160 = [u8; 20];
 pub type B256 = [u8; 32];
 
-/// libraries for no_std flag
-#[macro_use]
-extern crate alloc;
-use alloc::vec::Vec;
-use core::fmt;
 
 pub fn calc_linear_cost_u32(len: usize, base: u64, word: u64) -> u64 {
     (len as u64 + 32 - 1) / 32 * word + base

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -6,6 +6,7 @@ use core::{
     mem::size_of,
 };
 use num::{BigUint, One, Zero};
+use revm_primitives::Network;
 
 pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
     crate::u64_to_b176(5),
@@ -14,7 +15,7 @@ pub const BYZANTIUM: PrecompileAddress = PrecompileAddress(
 
 /// See: https://eips.ethereum.org/EIPS/eip-198
 /// See: https://etherscan.io/address/0000000000000000000000000000000000000005
-fn byzantium_run(input: &[u8], energy_limit: u64) -> PrecompileResult {
+fn byzantium_run(input: &[u8], energy_limit: u64, _: Network) -> PrecompileResult {
     run_inner(input, energy_limit, 0, |a, b, c, d| {
         byzantium_energy_calc(a, b, c, d)
     })
@@ -343,7 +344,7 @@ mod tests {
         for (test, &test_energy) in TESTS.iter().zip(BYZANTIUM_ENERGY.iter()) {
             let input = hex::decode(test.input).unwrap();
 
-            let res = byzantium_run(&input, 100_000_000).unwrap();
+            let res = byzantium_run(&input, 100_000_000, Network::Mainnet).unwrap();
             let expected = hex::decode(test.expected).unwrap();
             assert_eq!(
                 res.0, test_energy,

--- a/crates/precompile/src/modexp.rs
+++ b/crates/precompile/src/modexp.rs
@@ -1,7 +1,6 @@
 use crate::{
     primitives::U256, Error, Precompile, PrecompileAddress, PrecompileResult, StandardPrecompileFn,
 };
-use alloc::vec::Vec;
 use core::{
     cmp::{max, min, Ordering},
     mem::size_of,

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -1,8 +1,8 @@
-use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, StandardPrecompileFn};
-
+use revm_primitives::Network;
+use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, CustomPrecompileFn};
 pub const ECRECOVER: PrecompileAddress = PrecompileAddress(
     crate::u64_to_b176(1),
-    Precompile::Standard(ec_recover_run as StandardPrecompileFn),
+    Precompile::Custom(ec_recover_run as CustomPrecompileFn),
 );
 
 #[cfg(not(feature = "secp256k1"))]
@@ -35,27 +35,29 @@ mod secp256k1 {
 #[allow(clippy::module_inception)]
 mod secp256k1 {
     use crate::B256;
-    use secp256k1::{
-        ecdsa::{RecoverableSignature, RecoveryId},
-        Message, Secp256k1,
-    };
-    use sha3::{Digest, Keccak256};
+    use revm_primitives::{B160, to_ican, Network, B256 as rB256};
+    use sha3::{Digest, Sha3_256};
+    use libgoldilocks::goldilocks::ed448_verify_with_error;
 
-    pub fn ecrecover(sig: &[u8; 65], msg: &B256) -> Result<B256, secp256k1::Error> {
-        let sig =
-            RecoverableSignature::from_compact(&sig[0..64], RecoveryId::from_i32(sig[64] as i32)?)?;
+    pub fn ecrecover(sig: &[u8; 171], msg: &B256, network: Network) -> Result<B256, libgoldilocks::errors::LibgoldilockErrors> {
+        let mut sig_bytes = [0u8; 114];
+        let mut pub_bytes = [0u8; 57];
+        sig_bytes.copy_from_slice(&sig[0..114]);
+        pub_bytes.copy_from_slice(&sig[114..171]);
 
-        let secp = Secp256k1::new();
-        let public = secp.recover_ecdsa(&Message::from_slice(&msg[..32])?, &sig)?;
+        // Not sure whether this returns address(0) on invliad message
+        ed448_verify_with_error(&pub_bytes, &sig_bytes, msg.as_ref())?;
 
-        let hash = Keccak256::digest(&public.serialize_uncompressed()[1..]);
-        let mut hash: B256 = hash[..].try_into().unwrap();
-        hash.iter_mut().take(12).for_each(|i| *i = 0);
-        Ok(hash)
+        let hash = Sha3_256::digest(pub_bytes);
+        let hash: B256 = hash[..].try_into().unwrap();
+        let addr = B160::from_slice(&hash[12..]);
+        let addr = to_ican(&addr, &network);
+        let addr = rB256::from(addr);
+        Ok(*addr)
     }
 }
 
-fn ec_recover_run(i: &[u8], target_energy: u64) -> PrecompileResult {
+fn ec_recover_run(i: &[u8], target_energy: u64, network: Network)  -> PrecompileResult  {
     use core::cmp::min;
 
     const ECRECOVER_BASE: u64 = 3_000;
@@ -63,25 +65,49 @@ fn ec_recover_run(i: &[u8], target_energy: u64) -> PrecompileResult {
     if ECRECOVER_BASE > target_energy {
         return Err(Error::OutOfEnergy);
     }
-    let mut input = [0u8; 128];
-    input[..min(i.len(), 128)].copy_from_slice(&i[..min(i.len(), 128)]);
+
+    //                   msg+sig
+    let mut input = [0u8; 32+171];
+
+    // Copy the entire slice into input
+    input[..min(i.len(), 171+32)].copy_from_slice(&i[..min(i.len(), 171+32)]);
 
     let mut msg = [0u8; 32];
-    let mut sig = [0u8; 65];
-
+    let mut sig = [0u8; 171];
     msg[0..32].copy_from_slice(&input[0..32]);
-    sig[0..32].copy_from_slice(&input[64..96]);
-    sig[32..64].copy_from_slice(&input[96..128]);
+    sig[0..171].copy_from_slice(&input[32..171+32]);
 
-    if input[32..63] != [0u8; 31] || !matches!(input[63], 27 | 28) {
-        return Ok((ECRECOVER_BASE, Vec::new()));
-    }
-
-    sig[64] = input[63] - 27;
-
-    let out = secp256k1::ecrecover(&sig, &msg)
+    let out = secp256k1::ecrecover(&sig, &msg, network)
         .map(Vec::from)
         .unwrap_or_default();
 
     Ok((ECRECOVER_BASE, out))
+}
+
+#[cfg(test)]
+mod tests {
+    // use super::*;
+    use hex;
+    use crate::{B256, secp256k1::{secp256k1::ecrecover, ec_recover_run}};
+    use revm_primitives::Network;
+
+    #[test]
+    fn test_recover() {
+        let sig = hex::decode("611d178b128095022653965eb0ed3bc8bbea8e7891b5a121a102a5b29bb895770d204354dbbc67c5567186f92cdb58a601397dfe0022e0ce002c1333b6829c37c732fb909501f719df200ceaaa0e0a1533dc22e4c9c999406c071fee2858bc7c76c66d113ff1ac739564d465cd541b0d1e003761457fcdd53dba3dea5848c43aa54fe468284319f032945a3acb9bd4cd0fa7b7c901d978e9acd9eca43fa5b3c32b648c33dcc3f3169e8080").unwrap();
+        let sig: [u8; 171] = sig.try_into().unwrap();
+        let msg = hex::decode("f092a4af1f2103fe7be067df44370097c444f3bf877783ba56f21cf70ba365a3").unwrap();
+        let msg: [u8; 32] = msg.try_into().unwrap();
+        let msg = B256::from(msg);
+        let recovered = ecrecover(&sig, &msg, Network::Mainnet).unwrap();
+        let expected: [u8;32] = hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed").unwrap().try_into().unwrap();
+        assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn test_ecrecover() {
+        let sig = hex::decode("f092a4af1f2103fe7be067df44370097c444f3bf877783ba56f21cf70ba365a3611d178b128095022653965eb0ed3bc8bbea8e7891b5a121a102a5b29bb895770d204354dbbc67c5567186f92cdb58a601397dfe0022e0ce002c1333b6829c37c732fb909501f719df200ceaaa0e0a1533dc22e4c9c999406c071fee2858bc7c76c66d113ff1ac739564d465cd541b0d1e003761457fcdd53dba3dea5848c43aa54fe468284319f032945a3acb9bd4cd0fa7b7c901d978e9acd9eca43fa5b3c32b648c33dcc3f3169e8080").unwrap();
+        let recovered = ec_recover_run(&sig, 5000, Network::Mainnet).unwrap().1;
+        let expected: [u8;32] = hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed").unwrap().try_into().unwrap();
+        assert_eq!(recovered, expected);
+    }
 }

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -56,7 +56,6 @@ mod secp256k1 {
 }
 
 fn ec_recover_run(i: &[u8], target_energy: u64) -> PrecompileResult {
-    use alloc::vec::Vec;
     use core::cmp::min;
 
     const ECRECOVER_BASE: u64 = 3_000;

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -1,8 +1,8 @@
-use crate::{CustomPrecompileFn, Error, Precompile, PrecompileAddress, PrecompileResult};
+use crate::{StandardPrecompileFn, Error, Precompile, PrecompileAddress, PrecompileResult};
 use revm_primitives::Network;
 pub const ECRECOVER: PrecompileAddress = PrecompileAddress(
     crate::u64_to_b176(1),
-    Precompile::Custom(ec_recover_run as CustomPrecompileFn),
+    Precompile::Custom(ec_recover_run as StandardPrecompileFn),
 );
 
 #[cfg(not(feature = "secp256k1"))]

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -1,5 +1,5 @@
+use crate::{CustomPrecompileFn, Error, Precompile, PrecompileAddress, PrecompileResult};
 use revm_primitives::Network;
-use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, CustomPrecompileFn};
 pub const ECRECOVER: PrecompileAddress = PrecompileAddress(
     crate::u64_to_b176(1),
     Precompile::Custom(ec_recover_run as CustomPrecompileFn),
@@ -35,11 +35,15 @@ mod secp256k1 {
 #[allow(clippy::module_inception)]
 mod secp256k1 {
     use crate::B256;
-    use revm_primitives::{B160, to_ican, Network, B256 as rB256};
-    use sha3::{Digest, Sha3_256};
     use libgoldilocks::goldilocks::ed448_verify_with_error;
+    use revm_primitives::{to_ican, Network, B160, B256 as rB256};
+    use sha3::{Digest, Sha3_256};
 
-    pub fn ecrecover(sig: &[u8; 171], msg: &B256, network: Network) -> Result<B256, libgoldilocks::errors::LibgoldilockErrors> {
+    pub fn ecrecover(
+        sig: &[u8; 171],
+        msg: &B256,
+        network: Network,
+    ) -> Result<B256, libgoldilocks::errors::LibgoldilockErrors> {
         let mut sig_bytes = [0u8; 114];
         let mut pub_bytes = [0u8; 57];
         sig_bytes.copy_from_slice(&sig[0..114]);
@@ -57,7 +61,7 @@ mod secp256k1 {
     }
 }
 
-fn ec_recover_run(i: &[u8], target_energy: u64, network: Network)  -> PrecompileResult  {
+fn ec_recover_run(i: &[u8], target_energy: u64, network: Network) -> PrecompileResult {
     use core::cmp::min;
 
     const ECRECOVER_BASE: u64 = 3_000;
@@ -67,15 +71,15 @@ fn ec_recover_run(i: &[u8], target_energy: u64, network: Network)  -> Precompile
     }
 
     //                   msg+sig
-    let mut input = [0u8; 32+171];
+    let mut input = [0u8; 32 + 171];
 
     // Copy the entire slice into input
-    input[..min(i.len(), 171+32)].copy_from_slice(&i[..min(i.len(), 171+32)]);
+    input[..min(i.len(), 171 + 32)].copy_from_slice(&i[..min(i.len(), 171 + 32)]);
 
     let mut msg = [0u8; 32];
     let mut sig = [0u8; 171];
     msg[0..32].copy_from_slice(&input[0..32]);
-    sig[0..171].copy_from_slice(&input[32..171+32]);
+    sig[0..171].copy_from_slice(&input[32..171 + 32]);
 
     let out = secp256k1::ecrecover(&sig, &msg, network)
         .map(Vec::from)
@@ -87,19 +91,27 @@ fn ec_recover_run(i: &[u8], target_energy: u64, network: Network)  -> Precompile
 #[cfg(test)]
 mod tests {
     // use super::*;
+    use crate::{
+        secp256k1::{ec_recover_run, secp256k1::ecrecover},
+        B256,
+    };
     use hex;
-    use crate::{B256, secp256k1::{secp256k1::ecrecover, ec_recover_run}};
     use revm_primitives::Network;
 
     #[test]
     fn test_recover() {
         let sig = hex::decode("611d178b128095022653965eb0ed3bc8bbea8e7891b5a121a102a5b29bb895770d204354dbbc67c5567186f92cdb58a601397dfe0022e0ce002c1333b6829c37c732fb909501f719df200ceaaa0e0a1533dc22e4c9c999406c071fee2858bc7c76c66d113ff1ac739564d465cd541b0d1e003761457fcdd53dba3dea5848c43aa54fe468284319f032945a3acb9bd4cd0fa7b7c901d978e9acd9eca43fa5b3c32b648c33dcc3f3169e8080").unwrap();
         let sig: [u8; 171] = sig.try_into().unwrap();
-        let msg = hex::decode("f092a4af1f2103fe7be067df44370097c444f3bf877783ba56f21cf70ba365a3").unwrap();
+        let msg = hex::decode("f092a4af1f2103fe7be067df44370097c444f3bf877783ba56f21cf70ba365a3")
+            .unwrap();
         let msg: [u8; 32] = msg.try_into().unwrap();
         let msg = B256::from(msg);
         let recovered = ecrecover(&sig, &msg, Network::Mainnet).unwrap();
-        let expected: [u8;32] = hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed").unwrap().try_into().unwrap();
+        let expected: [u8; 32] =
+            hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed")
+                .unwrap()
+                .try_into()
+                .unwrap();
         assert_eq!(recovered, expected);
     }
 
@@ -107,7 +119,11 @@ mod tests {
     fn test_ecrecover() {
         let sig = hex::decode("f092a4af1f2103fe7be067df44370097c444f3bf877783ba56f21cf70ba365a3611d178b128095022653965eb0ed3bc8bbea8e7891b5a121a102a5b29bb895770d204354dbbc67c5567186f92cdb58a601397dfe0022e0ce002c1333b6829c37c732fb909501f719df200ceaaa0e0a1533dc22e4c9c999406c071fee2858bc7c76c66d113ff1ac739564d465cd541b0d1e003761457fcdd53dba3dea5848c43aa54fe468284319f032945a3acb9bd4cd0fa7b7c901d978e9acd9eca43fa5b3c32b648c33dcc3f3169e8080").unwrap();
         let recovered = ec_recover_run(&sig, 5000, Network::Mainnet).unwrap().1;
-        let expected: [u8;32] = hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed").unwrap().try_into().unwrap();
+        let expected: [u8; 32] =
+            hex::decode("00000000000000000000cb58fc37a3b370a1f22e2fe2f819c210895e098845ed")
+                .unwrap()
+                .try_into()
+                .unwrap();
         assert_eq!(recovered, expected);
     }
 }

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -33,7 +33,6 @@ mod secp256k1 {
     }
 }
 
-
 fn ec_recover_run(i: &[u8], target_energy: u64, network: Network) -> PrecompileResult {
     use core::cmp::min;
 

--- a/crates/precompile/src/secp256k1.rs
+++ b/crates/precompile/src/secp256k1.rs
@@ -1,4 +1,4 @@
-use crate::{StandardPrecompileFn, Error, Precompile, PrecompileAddress, PrecompileResult};
+use crate::{Error, Precompile, PrecompileAddress, PrecompileResult, StandardPrecompileFn};
 use revm_primitives::Network;
 pub const ECRECOVER: PrecompileAddress = PrecompileAddress(
     crate::u64_to_b176(1),

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -1,10 +1,11 @@
 use alloc::vec::Vec;
+use crate::Network;
 
 /// A precompile operation result.
 pub type PrecompileResult = Result<(u64, Vec<u8>), PrecompileError>;
 
 pub type StandardPrecompileFn = fn(&[u8], u64) -> PrecompileResult;
-pub type CustomPrecompileFn = fn(&[u8], u64) -> PrecompileResult;
+pub type CustomPrecompileFn = fn(&[u8], u64, Network) -> PrecompileResult;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PrecompileError {

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 /// A precompile operation result.
 pub type PrecompileResult = Result<(u64, Vec<u8>), PrecompileError>;
 
-pub type StandardPrecompileFn = fn(&[u8], u64) -> PrecompileResult;
+pub type StandardPrecompileFn = fn(&[u8], u64, Network) -> PrecompileResult;
 pub type CustomPrecompileFn = fn(&[u8], u64, Network) -> PrecompileResult;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/primitives/src/precompile.rs
+++ b/crates/primitives/src/precompile.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
 use crate::Network;
+use alloc::vec::Vec;
 
 /// A precompile operation result.
 pub type PrecompileResult = Result<(u64, Vec<u8>), PrecompileError>;

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -32,6 +32,19 @@ impl Network {
             Network::Private(n) => U256::from(*n),
         }
     }
+
+    pub fn from_prefix_numerical(prefix: u8) -> Self {
+        match prefix {
+            // CB
+            203 => Self::Mainnet,
+            // AB
+            171 => Self::Devin,
+            // Here we don't really care about the networkId because this function is only used in
+            // ecrecover, and we only need to know what should we prefix to the address from
+            // ecrecover
+            _ => Self::Private(100),
+        }
+    }
 }
 
 impl From<u64> for Network {

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -32,19 +32,6 @@ impl Network {
             Network::Private(n) => U256::from(*n),
         }
     }
-
-    pub fn from_prefix_numerical(prefix: u8) -> Self {
-        match prefix {
-            // CB
-            203 => Self::Mainnet,
-            // AB
-            171 => Self::Devin,
-            // Here we don't really care about the networkId because this function is only used in
-            // ecrecover, and we only need to know what should we prefix to the address from
-            // ecrecover
-            _ => Self::Private(100),
-        }
-    }
 }
 
 impl From<u64> for Network {

--- a/crates/primitives/src/utilities.rs
+++ b/crates/primitives/src/utilities.rs
@@ -83,7 +83,7 @@ pub fn create2_address(caller: B176, code_hash: B256, salt: U256, network_id: u6
     to_ican(&addr, &network)
 }
 
-fn to_ican(addr: &B160, network: &Network) -> B176 {
+pub fn to_ican(addr: &B160, network: &Network) -> B176 {
     // Get the prefix str
     let prefix = match network {
         Network::Mainnet => MAINNET,

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -739,7 +739,10 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 Precompile::Standard(fun) => fun(inputs.input.as_ref(), inputs.energy_limit),
                 Precompile::Custom(fun) => {
                     let network = inputs.contract.as_bytes();
-                    let network = Network::from(network[0] as u64);
+                    // This is kidn of a hack, we check the prefix of the calling contract, and
+                    // according to that we know what prefix to use for the ecrecover recovered
+                    // address.
+                    let network = Network::from_prefix_numerical(network[0]);
                     fun(inputs.input.as_ref(), inputs.energy_limit, network)
                 }
             };

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -178,7 +178,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                         context,
                         is_static: false,
                     };
-                    let (exit, energy, bytes) = self.call_inner(&mut call_input, Network::from(self.network_id));
+                    let (exit, energy, bytes) =
+                        self.call_inner(&mut call_input, Network::from(self.network_id));
                     (exit, energy, Output::Call(bytes))
                 } else {
                     (
@@ -658,7 +659,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         }
     }
 
-    fn call_inner(&mut self, inputs: &mut CallInputs, network: Network) -> (InstructionResult, Energy, Bytes) {
+    fn call_inner(
+        &mut self,
+        inputs: &mut CallInputs,
+        network: Network,
+    ) -> (InstructionResult, Energy, Bytes) {
         // Call the inspector
         if INSPECT {
             let (ret, energy, out) = self
@@ -736,10 +741,10 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         // Call precompiles
         let (ret, energy, out) = if let Some(precompile) = self.precompiles.get(&inputs.contract) {
             let out = match precompile {
-                Precompile::Standard(fun) => fun(inputs.input.as_ref(), inputs.energy_limit, network),
-                Precompile::Custom(fun) => {
+                Precompile::Standard(fun) => {
                     fun(inputs.input.as_ref(), inputs.energy_limit, network)
                 }
+                Precompile::Custom(fun) => fun(inputs.input.as_ref(), inputs.energy_limit, network),
             };
             match out {
                 Ok((energy_used, data)) => {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -178,7 +178,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                         context,
                         is_static: false,
                     };
-                    let (exit, energy, bytes) = self.call_inner(&mut call_input);
+                    let (exit, energy, bytes) = self.call_inner(&mut call_input, Network::from(self.network_id));
                     (exit, energy, Output::Call(bytes))
                 } else {
                     (
@@ -658,7 +658,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         }
     }
 
-    fn call_inner(&mut self, inputs: &mut CallInputs) -> (InstructionResult, Energy, Bytes) {
+    fn call_inner(&mut self, inputs: &mut CallInputs, network: Network) -> (InstructionResult, Energy, Bytes) {
         // Call the inspector
         if INSPECT {
             let (ret, energy, out) = self
@@ -736,13 +736,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         // Call precompiles
         let (ret, energy, out) = if let Some(precompile) = self.precompiles.get(&inputs.contract) {
             let out = match precompile {
-                Precompile::Standard(fun) => fun(inputs.input.as_ref(), inputs.energy_limit),
+                Precompile::Standard(fun) => fun(inputs.input.as_ref(), inputs.energy_limit, network),
                 Precompile::Custom(fun) => {
-                    let network = inputs.contract.as_bytes();
-                    // This is kidn of a hack, we check the prefix of the calling contract, and
-                    // according to that we know what prefix to use for the ecrecover recovered
-                    // address.
-                    let network = Network::from_prefix_numerical(network[0]);
                     fun(inputs.input.as_ref(), inputs.energy_limit, network)
                 }
             };
@@ -947,6 +942,6 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
     }
 
     fn call(&mut self, inputs: &mut CallInputs) -> (InstructionResult, Energy, Bytes) {
-        self.call_inner(inputs)
+        self.call_inner(inputs, Network::from(self.network_id))
     }
 }


### PR DESCRIPTION
This pr fixes the ecrecover precompile.

I removed the no_std in the precompiles crate, I don't really see why this would be relevant for us at the moment, and it was breaking a lot of stuff.